### PR TITLE
Fix key name for sending user id back on signup

### DIFF
--- a/auth/auth-router.js
+++ b/auth/auth-router.js
@@ -4,8 +4,6 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 
 function generateToken(user) {
-  console.log(user);
-
   const payload = {
     username: user.username,
     id: user.id,
@@ -34,7 +32,7 @@ router.post('/register', (req, res) => {
       res.status(201).json({
         message: 'User registration complete',
         token,
-        userId: id,
+        user_id: id,
       });
     })
     .catch((err) => {
@@ -75,7 +73,6 @@ router.post('/validate-token', (req, res) => {
           isAuthenticated: false,
         });
       } else {
-        console.log('over here');
         req.user = decodedToken;
         res.status(200).send({ isAuthenticated: true });
       }


### PR DESCRIPTION
# Description
Fixed the key name for sending back the user id on signup to match the key they're accessing on the frontend. Also deleted some console.logs

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
